### PR TITLE
Get smoke-test assertions working in DEBUG mode.

### DIFF
--- a/testing/react/src/ui/components/todo-mvc.tsx
+++ b/testing/react/src/ui/components/todo-mvc.tsx
@@ -7,7 +7,7 @@ import TodoList from './todo-list';
 export default class TodoMVC extends React.Component {
   render() {
     return (
-      <div>
+      <div data-test-todo-mvc>
         <h1>todos</h1>
 
         <div className='todoapp'>

--- a/testing/react/tests/acceptance/application-test.ts
+++ b/testing/react/tests/acceptance/application-test.ts
@@ -9,16 +9,17 @@ import page from 'tests/helpers/pages/todo-mvc';
 
 // usage: https://github.com/bigtestjs/react/blob/master/tests/setup-app-test.js
 describe('Acceptance | Application | renders', () => {
+  let app;
+
+  beforeEach(async () => {
+    app = await setupAppForTesting(Application);
+  })
 
   it('renders', async () => {
-    await setupAppForTesting(Application);
-
     expect(page.headingText).to.equal('todos');
   });
 
   it('resolves with the app', async () => {
-    const app = await setupAppForTesting(Application)
-
     expect(app).to.be.an.instanceOf(Application);
   });
 });

--- a/testing/react/tests/helpers/pages/todo-mvc.ts
+++ b/testing/react/tests/helpers/pages/todo-mvc.ts
@@ -14,4 +14,4 @@ export class TodoMVCPage {
   isEditing = isVisible('.editing');
 }
 
-export default new TodoMVCPage();
+export default new TodoMVCPage('[data-test-todo-mvc]');


### PR DESCRIPTION
Normally Karma runs all of its tests in an iframe. This allows it to sandbox the test environment from the actuall test runner inside the main Karma frame. However in debug mode, so that you can see the app and also run devtools it runs your tests in the main frame. However, you are subject to the main frames CSS as well as any global state that might be hanging around between test runs.

In this instance, the TodoMVC page object was looking for the first `h1` it found as the application's main heading. That was fine when it was running in a sandbox, but when running in the main frame it was finding Karma's navbar instead.

This adds a special class to the main React app so that the application interactor can be scoped to that selector. That way, it will work no matter which context it's in (unless there are multiple apps running at the same time, and in that case it will select the first)
